### PR TITLE
Attempt assembly download with ena portal if metagenome doesn't work

### DIFF
--- a/tests/test_ena_handler.py
+++ b/tests/test_ena_handler.py
@@ -257,8 +257,6 @@ class TestEnaHandler:
         runs = ena.get_study_runs(
             "SRP125161", filter_accessions=["SRR6301444"]
         )  # private=True was removed
-        print("RUNS HERE!!!!")
-        print(runs)
         assert len(runs) == 1
         for run in runs:
             assert 20 == len(run)

--- a/tests/test_ena_handler.py
+++ b/tests/test_ena_handler.py
@@ -257,6 +257,8 @@ class TestEnaHandler:
         runs = ena.get_study_runs(
             "SRP125161", filter_accessions=["SRR6301444"]
         )  # private=True was removed
+        print("RUNS HERE!!!!")
+        print(runs)
         assert len(runs) == 1
         for run in runs:
             assert 20 == len(run)


### PR DESCRIPTION
We need this for user generated assemblies which may not always be indexed the metagenome portal, e.g. metaT assemblies https://www.ebi.ac.uk/ena/browser/view/PRJEB61027